### PR TITLE
Fixed PCB LED flash

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -30,9 +30,9 @@ void setLedColor(uint8_t r, uint8_t g, uint8_t b )
     ledcWrite(RED_LED_PWM_CHANNEL, abs(LED_PWM_CONSTANT - map(max(r, g), 0, 255, 0, 75))); 
     ledcWrite(BLUE_LED_PWM_CHANNEL, abs(LED_PWM_CONSTANT - map(b, 0, 255, 0, 185)));
 #else
-    ledcWrite(RED_LED_PWM_CHANNEL, abs(LED_PWM_CONSTANT - r)); 
-    ledcWrite(GREEN_LED_PWM_CHANNEL, abs(LED_PWM_CONSTANT - g)); 
-    ledcWrite(BLUE_LED_PWM_CHANNEL, abs(LED_PWM_CONSTANT - b));
+    ledcWrite(RED_LED_PWM_CHANNEL, r); 
+    ledcWrite(GREEN_LED_PWM_CHANNEL, g); 
+    ledcWrite(BLUE_LED_PWM_CHANNEL, b);
 #endif
 #endif
 #ifdef ENABLE_TP_LED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,17 +79,25 @@ void setup()
 #endif
 
 #if ENABLE_PCB_LED
+    // Using GPIO.func_out_sel_cfg[pin].inv_sel = 1;
+    // Inverts the sense of the GPIO output.
+    // This must be done AFTER initialising PWM control for the GPIO pin
+    // This chage must be done in conjunction with removing sense invert
+    // in setLedColor() i.e. use 0-255 instead of 255-0
     ledcSetup(RED_LED_PWM_CHANNEL, PWM_FREQUENCY, PWM_RESOLUTION);
     ledcAttachPin(RED_LED_PIN, RED_LED_PWM_CHANNEL);
+    GPIO.func_out_sel_cfg[RED_LED_PIN].inv_sel = 1;
 #ifdef ENABLE_V_0_2_PCB_LED_FIX
     pinMode(COMMON_ANODE_PIN, OUTPUT);
     digitalWrite(COMMON_ANODE_PIN, LOW);  // Power off
 #else
     ledcSetup(GREEN_LED_PWM_CHANNEL, PWM_FREQUENCY, PWM_RESOLUTION);
     ledcAttachPin(GREEN_LED_PIN, GREEN_LED_PWM_CHANNEL);
+    GPIO.func_out_sel_cfg[GREEN_LED_PIN].inv_sel = 1;
 #endif
     ledcSetup(BLUE_LED_PWM_CHANNEL, PWM_FREQUENCY, PWM_RESOLUTION);
     ledcAttachPin(BLUE_LED_PIN, BLUE_LED_PWM_CHANNEL);
+    GPIO.func_out_sel_cfg[BLUE_LED_PIN].inv_sel = 1;
 #endif
 
     // Go to sleep immediately if woke up for something not related to deep sleep


### PR DESCRIPTION
PCB LED had dull glow after button push (and before main PCB light-up)
I tweaked the LED PWM GPIO to invert the sense of output so that setLedColour() no longer needs to set values as 255-x and instead can just use 'x'.
This also means that a "real" off is possible.
The PCB LED used to glow after button push/wakeup and before being set to the button colour.
Also, this setting occurs as soon as possible after initialising the PWM - otherwise, a bright 'white' flash occurred between the GPIOs being powered up and when the PWM is set up.
There is still a very small dull "blip" of the PCB led when a button is pushed.
I didn't touch the v0.2 PCB LED fix part of the code.